### PR TITLE
Use Spock's table syntax for multi-variable data-driven tests

### DIFF
--- a/src/test/groovy/LibraryDependencyTest.groovy
+++ b/src/test/groovy/LibraryDependencyTest.groovy
@@ -70,8 +70,11 @@ class LibraryDependencyTest extends Specification {
         result.output.trim() == majorVersion + ".x-develop-SNAPSHOT"
 
         where:
-        baseVersion << ['1.2.3', '1.1', '4.2', '3.2.1']
-        majorVersion << ['1', '1', '4', '3']
+        baseVersion || majorVersion
+        '1.2.3'     || '1'
+        '1.1'       || '1'
+        '4.2'       || '4'
+        '3.2.1'     || '3'
     }
 
     @Unroll
@@ -87,9 +90,11 @@ class LibraryDependencyTest extends Specification {
         result.output.trim() == majorVersion + ".x-develop-SNAPSHOT"
 
         where:
-        branch << ['feature/GAT-123-text-that-should-be-cut-off', 'feature/arbitrary-branch', 'MOCOM-423-amazing-feature', 'quick-fix']
-        baseVersion << ['3.4', '9.4.1', '0.5', '6.2.3']
-        majorVersion << ['3', '9', '0', '6']
+        branch                                        | baseVersion || majorVersion
+        'feature/GAT-123-text-that-should-be-cut-off' | '3.4'       || '3'
+        'feature/arbitrary-branch'                    | '9.4.1'     || '9'
+        'MOCOM-423-amazing-feature'                   | '0.5'       || '0'
+        'quick-fix'                                   | '6.2.3'     || '6'
     }
 
     @Unroll

--- a/src/test/groovy/LibraryNameTest.groovy
+++ b/src/test/groovy/LibraryNameTest.groovy
@@ -71,8 +71,11 @@ class LibraryNameTest extends Specification {
         result.output.trim() == majorVersion + ".x-develop-SNAPSHOT"
 
         where:
-        baseVersion << ['1.2.3', '1.1', '4.2', '3.2.1']
-        majorVersion << ['1', '1', '4', '3']
+        baseVersion || majorVersion
+        '1.2.3'     || '1'
+        '1.1'       || '1'
+        '4.2'       || '4'
+        '3.2.1'     || '3'
     }
 
     @Unroll
@@ -87,8 +90,10 @@ class LibraryNameTest extends Specification {
         result.output.trim() == jiraKey + "-SNAPSHOT"
 
         where:
-        branch << ['feature/GAT-123-text-that-should-be-cut-off', 'feature/MOCOM-1212-arbitrary', 'feature/GIOCPIIA-1-description']
-        jiraKey << ['GAT-123', 'MOCOM-1212', 'GIOCPIIA-1']
+        branch                                        || jiraKey
+        'feature/GAT-123-text-that-should-be-cut-off' || 'GAT-123'
+        'feature/MOCOM-1212-arbitrary'                || 'MOCOM-1212'
+        'feature/GIOCPIIA-1-description'              || 'GIOCPIIA-1'
     }
 
     @Unroll
@@ -103,8 +108,11 @@ class LibraryNameTest extends Specification {
         result.output.trim() == jiraKey + "-SNAPSHOT"
 
         where:
-        branch << ['feature/gat-123-text', 'feature/MocoM-1212-arbitrary', 'GioCPiiA-1-description', 'ga-9-short']
-        jiraKey << ['GAT-123', 'MOCOM-1212', 'GIOCPIIA-1', 'GA-9']
+        branch                         || jiraKey
+        'feature/gat-123-text'         || 'GAT-123'
+        'feature/MocoM-1212-arbitrary' || 'MOCOM-1212'
+        'GioCPiiA-1-description'       || 'GIOCPIIA-1'
+        'ga-9-short'                   || 'GA-9'
     }
 
     @Unroll
@@ -119,8 +127,10 @@ class LibraryNameTest extends Specification {
         result.output.trim() == jiraKey + "-SNAPSHOT"
 
         where:
-        branch << ['GGG-453-get-rid-of-this', 'GIOCP-123123-something', 'GA-9-short']
-        jiraKey << ['GGG-453', 'GIOCP-123123', 'GA-9']
+        branch                    || jiraKey
+        'GGG-453-get-rid-of-this' || 'GGG-453'
+        'GIOCP-123123-something'  || 'GIOCP-123123'
+        'GA-9-short'              || 'GA-9'
     }
 
     @Unroll


### PR DESCRIPTION
I learned over the weekend that Spock supports a much nicer way to represent data in data-driven tests, so I figured I'd move us over to using them here.